### PR TITLE
Enable sandboxed visualisations

### DIFF
--- a/mindmap1.html
+++ b/mindmap1.html
@@ -658,7 +658,7 @@ function applyView(){
 // PAN / ZOOM / DRAG
 let pan=false, startP={}, startV={};
 viewportContainer.addEventListener('pointerdown',e=>{
-  if(e.target.closest('#sidepanel') || e.target.closest('.popup') || e.target.closest('#modeToggle')) return;
+  if(e.target.closest('.node') || e.target.closest('#sidepanel') || e.target.closest('.popup') || e.target.closest('#modeToggle')) return;
   closeMenus();
   pan=true;
   viewportContainer.setPointerCapture(e.pointerId);

--- a/mindmap1.html
+++ b/mindmap1.html
@@ -716,6 +716,12 @@ function enableNodeEvents(el,n){
     document.addEventListener('pointermove',mv);
     document.addEventListener('pointerup',up);
   });
+  /* fallback so taps trigger even if pointerup is swallowed */
+  el.addEventListener('click',e=>{
+    if(dragging) return;
+    e.stopPropagation();
+    openPopup(n);
+  });
   el.addEventListener('contextmenu',e=>{
     e.preventDefault();
     closeMenus();

--- a/mindmap1.html
+++ b/mindmap1.html
@@ -85,149 +85,7 @@
 </style>
 </head>
 <body>
-<!-- ╔══════════════════════════════════════════════════════════╗
-     ║  REVERSE-FAMILY TREE – edge-gap guarantee (v17)          ║
-     ╚══════════════════════════════════════════════════════════╝ -->
-     <script>
-      (function tidyTreeEdgeGap () {
-      
-      /* ── CONFIG KNOBS ─────────────────────────────────────────── */
-      const TOP_PAD    = 60;      // root’s top edge from viewport
-      const ROW_GAP    = 300;     // vertical gap between generations
-      const EDGE_GAP   = 200;      // 🔸 minimum empty space (edge-to-edge)
-      const MAX_FRAC   = 5;    // max allowed width fraction
-      
-      /* ── WAIT FOR HOST MAP ────────────────────────────────────── */
-      (function wait () {
-        try { if (typeof build === 'function' && Array.isArray(nodes)) return patch(); }
-        catch { /* script not loaded yet */ }
-        setTimeout(wait, 0);
-      })();
-      
-      /* ── MAIN PATCH ───────────────────────────────────────────── */
-      function patch () {
-        if (build._edgeGapV17) return;      // already applied
-      
-        /* 1 ▸ root + orphans */
-        const root = nodes.find(n => /^syllabus\b/i.test(n.label)) || nodes[0];
-        nodes.forEach(n => { if (n !== root && n.parent == null) n.parent = root.id; });
-      
-        /* 2 ▸ children lookup */
-        const kids = {};
-        nodes.forEach(n => { if (n.parent != null) (kids[n.parent] ||= []).push(n); });
-      
-        /* 3 ▸ measure real box sizes */
-        function measure () {
-          const probe = document.createElement('div');
-          probe.style.cssText = 'position:absolute;visibility:hidden;';
-          document.body.appendChild(probe);
-          nodes.forEach(n => {
-            probe.className = 'node';
-            probe.innerHTML = `<div>${n.label}</div>`;
-            const r = probe.getBoundingClientRect();
-            n._w = r.width; n._h = r.height;
-          });
-          document.body.removeChild(probe);
-        }
-      
-        /* 4 ▸ compute subtree widths (edge-gap aware) */
-        const subW = new Map();
-        function width(n) {
-          const ch = kids[n.id] || [];
-          if (!ch.length) return subW.set(n, n._w).get(n);
-          const totalKids = ch.reduce((sum,c)=> sum + width(c), 0);
-          const gaps      = EDGE_GAP * (ch.length - 1);
-          return subW.set(n, Math.max(n._w, totalKids + gaps)).get(n);
-        }
-      
-        /* 5 ▸ place nodes (strict L→R) */
-        function place(n, leftEdge, depth) {
-          n.y = TOP_PAD + depth * ROW_GAP;
-          n.x = leftEdge + subW.get(n) / 2;
-      
-          const ch = kids[n.id] || [];
-          if (!ch.length) return;
-      
-          let cursor = leftEdge;
-          ch.forEach(c => {
-            place(c, cursor, depth + 1);
-            cursor += subW.get(c) + EDGE_GAP;
-          });
-        }
-      
-        /* 6 ▸ squeeze if too wide, then centre */
-        function fitAndCenter () {
-          let minX = Math.min(...nodes.map(n => n.x - n._w/2));
-          let maxX = Math.max(...nodes.map(n => n.x + n._w/2));
-          let W    = maxX - minX;
-      
-          if (W > innerWidth * MAX_FRAC) {
-            const f  = (innerWidth * MAX_FRAC) / W;
-            const cx = (minX + maxX) / 2;
-            nodes.forEach(n => n.x = (n.x - cx) * f + cx);
-            minX = Math.min(...nodes.map(n => n.x - n._w/2));
-            maxX = Math.max(...nodes.map(n => n.x + n._w/2));
-            W    = maxX - minX;
-          }
-          const offset = (innerWidth - W)/2 - minX;
-          nodes.forEach(n => n.x += offset);
-        }
-      
-        /* 7 ▸ apply positions to DOM */
-        function pushDOM () {
-          document.querySelectorAll('#mindmap .node')
-            .forEach((el,i)=>{
-              const n = nodes[i];
-              el.style.left = `${n.x}px`;
-              el.style.top  = `${n.y + n._h/2}px`;
-            });
-        }
-      
-        /* 8 ▸ redraw smooth connectors */
-        updateLinks = function () {
-          linkEls.forEach(({l,node})=>{
-            const p = nodes.find(k=>k.id===node.parent);
-            if (!p) { l.setAttribute('d', ''); return; }
-            const pB = p.y + p._h;
-            const cT = node.y;
-            if (cT <= pB){ l.setAttribute('d',''); return; }
-            const midY = (pB + cT)/2;
-            l.removeAttribute('marker-end');
-            l.setAttribute('d',
-              `M ${p.x} ${pB} C ${p.x} ${midY} ${node.x} ${midY} ${node.x} ${cT}`);
-          });
-        };
-      
-        /* 9 ▸ viewport snap */
-        function snap () {
-          view.scale = 1;
-          const minX = Math.min(...nodes.map(n => n.x - n._w/2));
-          const maxX = Math.max(...nodes.map(n => n.x + n._w/2));
-          view.x = innerWidth/2 - (minX+maxX)/2;
-          view.y = 0;
-          applyView();
-        }
-      
-        /* 10 ▸ wrap host build() */
-        const hostBuild = build;
-        build = function () {
-          hostBuild.apply(this, arguments);
-          measure();            // sizes first
-          width(root);          // subtree widths
-          place(root, 0, 0);    // coordinates
-          fitAndCenter();       // squeeze & centre
-          pushDOM();            // move DOM nodes
-          updateLinks();        // bend links
-          snap();               // centre viewport
-        };
-        build._edgeGapV17 = true;
-      
-        /* first render */
-        try { build(); } catch {}
-      }
-      })();
-      </script>
-      
+
   <div id="sidepanel" class="collapsed">
     <div id="sideToggle">→</div>
     <h3>Mind-Map DSL</h3>
@@ -1152,7 +1010,7 @@ refresh();
 /* ---- Mind‑Map Extra Features ---- */
 (function(){
   /* ---------- Helpers ---------- */
-  function renderVisualisations(container){
+  window.renderVisualisations = function(container){
     container.querySelectorAll('visualisation').forEach(el=>{
       const code=el.innerHTML;
       const block=document.createElement('div');
@@ -1165,7 +1023,7 @@ refresh();
       el.after(block);
     });
   }
-  function removeVisualisations(container){
+  window.removeVisualisations = function(container){
     container.querySelectorAll('.visBlock').forEach(b=>b.remove());
     container.querySelectorAll('visualisation').forEach(el=>{
       el.style.display='';

--- a/mindmap1.html
+++ b/mindmap1.html
@@ -85,55 +85,167 @@
 </style>
 </head>
 <body>
-
+<!-- ╔══════════════════════════════════════════════════════════╗
+     ║  REVERSE-FAMILY TREE – edge-gap guarantee (v17)          ║
+     ╚══════════════════════════════════════════════════════════╝ -->
+     <script>
+      (function tidyTreeEdgeGap () {
+      
+      /* ── CONFIG KNOBS ─────────────────────────────────────────── */
+      const TOP_PAD    = 60;      // root’s top edge from viewport
+      const ROW_GAP    = 300;     // vertical gap between generations
+      const EDGE_GAP   = 200;      // 🔸 minimum empty space (edge-to-edge)
+      const MAX_FRAC   = 6;    // max allowed width fraction
+      
+      /* ── WAIT FOR HOST MAP ────────────────────────────────────── */
+      (function wait () {
+        try { if (typeof build === 'function' && Array.isArray(nodes)) return patch(); }
+        catch { /* script not loaded yet */ }
+        setTimeout(wait, 0);
+      })();
+      
+      /* ── MAIN PATCH ───────────────────────────────────────────── */
+      function patch () {
+        if (build._edgeGapV17) return;      // already applied
+      
+        /* 1 ▸ root + orphans */
+        const root = nodes.find(n => /^syllabus\b/i.test(n.label)) || nodes[0];
+        nodes.forEach(n => { if (n !== root && n.parent == null) n.parent = root.id; });
+      
+        /* 2 ▸ children lookup */
+        const kids = {};
+        nodes.forEach(n => { if (n.parent != null) (kids[n.parent] ||= []).push(n); });
+      
+        /* 3 ▸ measure real box sizes */
+        function measure () {
+          const probe = document.createElement('div');
+          probe.style.cssText = 'position:absolute;visibility:hidden;';
+          document.body.appendChild(probe);
+          nodes.forEach(n => {
+            probe.className = 'node';
+            probe.innerHTML = `<div>${n.label}</div>`;
+            const r = probe.getBoundingClientRect();
+            n._w = r.width; n._h = r.height;
+          });
+          document.body.removeChild(probe);
+        }
+      
+        /* 4 ▸ compute subtree widths (edge-gap aware) */
+        const subW = new Map();
+        function width(n) {
+          const ch = kids[n.id] || [];
+          if (!ch.length) return subW.set(n, n._w).get(n);
+          const totalKids = ch.reduce((sum,c)=> sum + width(c), 0);
+          const gaps      = EDGE_GAP * (ch.length - 1);
+          return subW.set(n, Math.max(n._w, totalKids + gaps)).get(n);
+        }
+      
+        /* 5 ▸ place nodes (strict L→R) */
+        function place(n, leftEdge, depth) {
+          n.y = TOP_PAD + depth * ROW_GAP;
+          n.x = leftEdge + subW.get(n) / 2;
+      
+          const ch = kids[n.id] || [];
+          if (!ch.length) return;
+      
+          let cursor = leftEdge;
+          ch.forEach(c => {
+            place(c, cursor, depth + 1);
+            cursor += subW.get(c) + EDGE_GAP;
+          });
+        }
+      
+        /* 6 ▸ squeeze if too wide, then centre */
+        function fitAndCenter () {
+          let minX = Math.min(...nodes.map(n => n.x - n._w/2));
+          let maxX = Math.max(...nodes.map(n => n.x + n._w/2));
+          let W    = maxX - minX;
+      
+          if (W > innerWidth * MAX_FRAC) {
+            const f  = (innerWidth * MAX_FRAC) / W;
+            const cx = (minX + maxX) / 2;
+            nodes.forEach(n => n.x = (n.x - cx) * f + cx);
+            minX = Math.min(...nodes.map(n => n.x - n._w/2));
+            maxX = Math.max(...nodes.map(n => n.x + n._w/2));
+            W    = maxX - minX;
+          }
+          const offset = (innerWidth - W)/2 - minX;
+          nodes.forEach(n => n.x += offset);
+        }
+      
+        /* 7 ▸ apply positions to DOM */
+        function pushDOM () {
+          document.querySelectorAll('#mindmap .node')
+            .forEach((el,i)=>{
+              const n = nodes[i];
+              el.style.left = `${n.x}px`;
+              el.style.top  = `${n.y + n._h/2}px`;
+            });
+        }
+      
+        /* 8 ▸ redraw smooth connectors */
+        updateLinks = function () {
+          linkEls.forEach(({l,node})=>{
+            const p = nodes.find(k=>k.id===node.parent);
+            if (!p) { l.setAttribute('d', ''); return; }
+            const pB = p.y + p._h;
+            const cT = node.y;
+            if (cT <= pB){ l.setAttribute('d',''); return; }
+            const midY = (pB + cT)/2;
+            l.removeAttribute('marker-end');
+            l.setAttribute('d',
+              `M ${p.x} ${pB} C ${p.x} ${midY} ${node.x} ${midY} ${node.x} ${cT}`);
+          });
+        };
+      
+        /* 9 ▸ viewport snap */
+        function snap () {
+          view.scale = 1;
+          const minX = Math.min(...nodes.map(n => n.x - n._w/2));
+          const maxX = Math.max(...nodes.map(n => n.x + n._w/2));
+          view.x = innerWidth/2 - (minX+maxX)/2;
+          view.y = 0;
+          applyView();
+        }
+      
+        /* 10 ▸ wrap host build() */
+        const hostBuild = build;
+        build = function () {
+          hostBuild.apply(this, arguments);
+          measure();            // sizes first
+          width(root);          // subtree widths
+          place(root, 0, 0);    // coordinates
+          fitAndCenter();       // squeeze & centre
+          pushDOM();            // move DOM nodes
+          updateLinks();        // bend links
+          snap();               // centre viewport
+        };
+        build._edgeGapV17 = true;
+      
+        /* first render */
+        try { build(); } catch {}
+      }
+      })();
+      </script>
+      
   <div id="sidepanel" class="collapsed">
     <div id="sideToggle">→</div>
     <h3>Mind-Map DSL</h3>
     <textarea id="dslInput" spellcheck="false">
-    Syllabus 🗂️ | size=1.6 | color=#4fc3f7 /* light-blue 💧 */ | notes=<strong>Course overview: Numerical Methods for Differential Equations</strong>
-      Approximation & Interpolation 🎯 | size=1.3 | color=#ffe0b2 /* pastel-peach 🍑 */ | notes=<strong>Finding simple functions that mimic complex ones: interpolation fits exactly through given points (Lagrange, Chebyshev, splines), approximation fits “as close as possible” (least-squares, regression, NURBS). Used for data fitting, graphics, and simulations. Key ideas: avoid overfitting (Runge’s phenomenon), prefer Chebyshev nodes for stability, and use splines for smoothness. Example: interpolation hits all data points, approximation finds best fit for noisy data.</strong>
-        Interpolation 📍 | size=1.0 | color=#ffd54f /* sunflower 🌻 */  
-          Vandermonde Matrix | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          Lagrange Formula | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          Error Analysis & Runge Phenomenon | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          Chebyshev Nodes | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          Cubic Splines | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-        Approximation 🎨 | size=1.0 | color=#ffd54f /* sunflower 🌻 */  
-          Polynomial Regression | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          Orthogonal Projection & Least Squares | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          NURBS & B-splines | size=0.8 | color=#ffecb3 /* ivory 🌼 */ | notes=<strong>B-splines</strong> are ==piecewise polynomial== curves with local control and smoothness.<visualisation><svg viewBox="0 0 200 120" width="200" height="120"><polyline points="20,100 60,20 100,100 140,30 180,100" fill="none" stroke="#999" stroke-dasharray="4"/><path d="M20,100 C40,50 80,50 100,100 S160,150 180,100" fill="none" stroke="royalblue" stroke-width="3"/></svg></visualisation>
-      Numerical Integration 📏 | size=1.3 | color=#ffb74d /* amber-orange 🍊 */ | notes=<ul><li>Newton-Cotes</li><li>Gauss</li><li>Adaptive, Romberg</li></ul>
-        Newton-Cotes Closed | size=1.0 | color=#ffe082 /* brass ⭐ */  
-          Trapezoidal & Simpson | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          Composite Rules & Error Bounds | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-        Gauss-Legendre Quadrature | size=1.0 | color=#ffe082 /* brass ⭐ */  
-        Recursive & Adaptive Methods 🔄 | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          Richardson Extrapolation | size=0.6 | color=#e0f7fa /* mint 🌿 */  
-          Romberg Integration | size=0.6 | color=#e0f7fa /* mint 🌿 */  
-          Adaptive Subdivision | size=0.6 | color=#e0f7fa /* mint 🌿 */  
-      Numerical Differentiation 🔢 | size=1.3 | color=#a5d6a7 /* mint-green 🌱 */ | notes=<ul><li>Finite differences</li><li>Errors & stability</li></ul>
-        Finite Difference Formulas | size=1.0 | color=#c8e6c9 /* pale-green 🌾 */  
-          Forward & Backward (O(h²)) | size=0.8 | color=#e8f5e9 /* lily 🌸 */  
-          Central (O(h²), O(h⁴)) | size=0.8 | color=#e8f5e9 /* lily 🌸 */  
-        Round-off Error Analysis ⚠️ | size=0.8 | color=#e8f5e9 /* lily 🌸 */  
-          Floating-point Arithmetic | size=0.6 | color=#f0f4c3 /* lemon 🍋 */  
-          Optimal Step-size Choice | size=0.6 | color=#f0f4c3 /* lemon 🍋 */  
-      Initial Value Problems 🌐 | size=1.3 | color=#ce93d8 /* lavender 🌸 */ | notes=<ul><li>One-step & multistep methods</li><li>Stability</li></ul>
-        Stability of ODEs | size=1.0 | color=#e1bee7 /* lilac 🌺 */  
-        Taylor & Euler Methods | size=0.8 | color=#f3e5f5 /* orchid 🌷 */  
-        Runge-Kutta Family | size=0.8 | color=#f3e5f5 /* orchid 🌷 */  
-        Multistep (Adams, Gear) | size=0.8 | color=#f3e5f5 /* orchid 🌷 */  
-      Nonlinear Equations 🔎 | size=1.3 | color=#90caf9 /* sky-blue ☁️ */ | notes=<ul><li>Bisection to Newton</li></ul>
-        Bisection & Fixed Point | size=1.0 | color=#bbdefb /* powder-blue 🌬 */  
-        Newton-Raphson & Secant | size=1.0 | color=#bbdefb /* powder-blue 🌬 */  
-        Systems & Nonlinear Optimization | size=0.8 | color=#e3f2fd /* silk 🌨 */  
-      Boundary Value Problems 🏁 | size=1.3 | color=#ffcc80 /* peach 🍑 */ | notes=<ul><li>Finite differences</li><li>Heat, wave, Poisson</li></ul>
-        Poisson via Finite Differences | size=1.0 | color=#ffe0b2 /* pastel-peach 🍑 */  
-        Heat Equation & Stability | size=0.8 | color=#fff3e0 /* cream 🍦 */  
-        Wave Equation & Dispersion | size=0.8 | color=#fff3e0 /* cream 🍦 */  
-      Fun, Frustrations & Tricks 🎉 | size=1.3 | color=#b0bec5 /* slate-gray 🪨 */ | notes=<em>Insights & best practices</em>
-        Numerical Challenges & Tips | size=1.0 | color=#cfd8dc /* mist 🌫 */  
-        Practical Software (MATLAB, Python) | size=0.8 | color=#cfd8dc /* mist 🌫 */  
+Calculus III & Vector Analysis (2022–2025 exams) 🧭 | size=1.8 | color=#29b6f6 /* blue 💧 */ | notes=<strong>Welcome! This map is your complete guide to mastering multivariable calculus & vector analysis as examined in 2022–2025. Every big petal is a top exam topic; smaller ones are crucial basics. Bigger nodes = higher chance on exams; color groups related ideas. Use this map by: 1) Starting at the biggest node you don’t know; 2) Reading its clear explanation; 3) Doing its worked example and all five exercises; 4) Moving outward to smaller petals. Each step is packed with short, beginner-friendly, emoji-rich tips. Even if you’re shaky, just follow the petals: the deepest leaves have the most detailed, stepwise examples, so you’ll be able to solve real past-paper questions by the end.</strong> | question="How do I use this mind map for effective revision?" | steps="1. Start at the centre (biggest node); 2. Read the explanation for the first main petal; 3. Work through the example for that petal; 4. Try all five practice questions for that petal; 5. Repeat with next main petal, moving outward" | solution="For example, if the 'Surface Integrals & Flux Computations' node is biggest, read its notes, follow the step-by-step flux example, then attempt each exercise. Move on only when you can do every step yourself." | notes2=<ul><li>Open the map and find the biggest blue petal (most important for the exam)</li><li>Read the worked example for that petal (real past exam, step-by-step)</li><li>Solve the easiest exercise—write out every step</li><li>Try the hardest exercise for that petal—even if you get stuck</li><li>Tick off the petal when you can explain it to a friend</li></ul>
+
+  Taylor Series & Extremum Classification 📈 | size=1.0 | color=#ff7043 /* orange 🍊 */ | notes=<ul><li>Taylor expansion: up to 2nd order</li><li>Classify critical points via Hessian</li><li>Use remainder for error bounds</li></ul>
+    Classification des extremums locaux | size=0.6 | color=#ff7043 /* orange 🍊 */ | notes=<em>Hessian test for min/max/saddle</em> | question="How do you classify extrema of f(x, y)?" | steps="Find grad=0; Compute Hessian; Analyze eigenvalues"
+    Développement limité (Taylor) | size=0.6 | color=#ff7043 /* orange 🍊 */ | notes=<em>Taylor polynomial up to 2nd order</em> | question="How to find Taylor expansion of f(x, y)?" | steps="Compute derivatives; Build T2 formula"
+    Reste et estimation d’erreur | size=0.6 | color=#ff7043 /* orange 🍊 */ | notes=<em>Bound error using Lagrange or integral form</em> | question="How do you estimate the remainder/error in Taylor?" | steps="Write remainder; Bound with derivatives"
+    Minimum global sur un domaine fermé | size=0.6 | color=#ff7043 /* orange 🍊 */ | notes=<em>Find global extrema using Hessian and endpoints</em> | question="How to check for global minimum?" | steps="Classify criticals; Check boundary"
+
+  Conservative Fields & Exact Differentials 🧲 | size=0.7 | color=#66bb6a /* green 🌿 */ | notes=<ul><li>Test for conservativeness: curl F = 0</li><li>Find potential function</li></ul>
+    Champ gradient | size=0.4 | color=#66bb6a /* green 🌿 */ | notes=<em>Find scalar potential</em> | question="How do you find a potential function for F?" | steps="Integrate component-wise; Match cross-derivatives"
+    Test d’exactitude | size=0.4 | color=#66bb6a /* green 🌿 */ | notes=<em>Use equality of mixed partials</em> | question="How to check if a differential form is exact?" | steps="Compare ∂M/∂y and ∂N/∂x"
+    Chemin indépendant | size=0.4 | color=#66bb6a /* green 🌿 */ | notes=<em>If conservative, integral is path-independent</em> | question="When is a line integral independent of path?" | steps="Show field is conservative"
+
+
     
     </textarea>
 <!-- ╔════════════════════════════════════════════════════╗
@@ -516,7 +628,7 @@ function applyView(){
 // PAN / ZOOM / DRAG
 let pan=false, startP={}, startV={};
 viewportContainer.addEventListener('pointerdown',e=>{
-  if(e.target.closest('.node') || e.target.closest('#sidepanel') || e.target.closest('.popup') || e.target.closest('#modeToggle')) return;
+  if(e.target.closest('#sidepanel') || e.target.closest('.popup') || e.target.closest('#modeToggle')) return;
   closeMenus();
   pan=true;
   viewportContainer.setPointerCapture(e.pointerId);
@@ -573,12 +685,6 @@ function enableNodeEvents(el,n){
     };
     document.addEventListener('pointermove',mv);
     document.addEventListener('pointerup',up);
-  });
-  /* fallback so taps trigger even if pointerup is swallowed */
-  el.addEventListener('click',e=>{
-    if(dragging) return;
-    e.stopPropagation();
-    openPopup(n);
   });
   el.addEventListener('contextmenu',e=>{
     e.preventDefault();
@@ -848,7 +954,11 @@ function openPopup(n) {
     removeVisualisations(page);
     n.notes = page.innerHTML;  // save WITH the generated HTML
     renderVisualisations(page);
+
+    const keep = { ...view };   // preserve current viewport
     build();
+    view = keep;
+    applyView();
   };
 
   p.querySelector(".iconBtn").onclick = () => { saveAndClose(); ov.remove(); };
@@ -1012,12 +1122,12 @@ refresh();
   /* ---------- Helpers ---------- */
   window.renderVisualisations = function(container){
     container.querySelectorAll('visualisation').forEach(el=>{
-      const code=el.innerHTML;
+      const code=el.textContent;
       const block=document.createElement('div');
       block.className='visBlock';
       const frame=document.createElement('iframe');
       frame.setAttribute('sandbox','allow-scripts');
-      frame.srcdoc=code;
+      frame.srcdoc='<!DOCTYPE html><html><body>'+code+'</body></html>';
       block.appendChild(frame);
       el.style.display='none';
       el.after(block);

--- a/mindmap1.html
+++ b/mindmap1.html
@@ -33,13 +33,14 @@
   #sideToggle { position:absolute;top:8px;right:-28px;width:26px;height:26px;border-radius:50%;background:var(--menu-bg);border:3px solid var(--node-border);display:flex;align-items:center;justify-content:center;cursor:pointer; }
 
   /* MODE TOGGLE */
-  #modeToggle { position:fixed;top:1rem;right:1rem;z-index:95;border:2px solid var(--text);border-radius:12px;padding:.35rem .6rem;display:flex;align-items:center;background:var(--bg); }
+  #modeToggle { position:fixed;top:1rem;right:1rem;z-index:95;border:2px solid var(--text);border-radius:12px;padding:.35rem .6rem;display:flex;align-items:center;background:var(--bg);cursor:pointer; }
   #modeToggle svg { width:20px;height:20px;stroke:currentColor;fill:none;stroke-width:2.3; }
 
   /* CANVAS */
-  #viewportContainer { position:absolute;inset:0; }
-  #viewport { position:absolute;inset:0;touch-action:none;cursor:grab; }
-  #viewport:active { cursor:grabbing; }
+#viewportContainer { position:absolute;inset:0;touch-action:none;cursor:grab; }
+#viewportContainer:active { cursor:grabbing; }
+#viewport { position:absolute;inset:0;touch-action:none;cursor:inherit; }
+#viewport:active { cursor:inherit; }
   svg#links { position:absolute;inset:0;overflow:visible;pointer-events:none; }
   #mindmap { position:absolute;inset:0;pointer-events:none; }
 
@@ -242,7 +243,7 @@
         Approximation 🎨 | size=1.0 | color=#ffd54f /* sunflower 🌻 */  
           Polynomial Regression | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
           Orthogonal Projection & Least Squares | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
-          NURBS & B-splines | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
+          NURBS & B-splines | size=0.8 | color=#ffecb3 /* ivory 🌼 */ | notes=<strong>B-splines</strong> are ==piecewise polynomial== curves with local control and smoothness.<visualisation><svg viewBox="0 0 200 120" width="200" height="120"><polyline points="20,100 60,20 100,100 140,30 180,100" fill="none" stroke="#999" stroke-dasharray="4"/><path d="M20,100 C40,50 80,50 100,100 S160,150 180,100" fill="none" stroke="royalblue" stroke-width="3"/></svg></visualisation>
       Numerical Integration 📏 | size=1.3 | color=#ffb74d /* amber-orange 🍊 */ | notes=<ul><li>Newton-Cotes</li><li>Gauss</li><li>Adaptive, Romberg</li></ul>
         Newton-Cotes Closed | size=1.0 | color=#ffe082 /* brass ⭐ */  
           Trapezoidal & Simpson | size=0.8 | color=#ffecb3 /* ivory 🌼 */  
@@ -344,7 +345,8 @@ const ICONS = {
 };
 
 // GLOBALS
-const viewport = document.getElementById('viewport'),
+const viewport        = document.getElementById('viewport'),
+      viewportContainer = document.getElementById('viewportContainer'),
       svg      = document.getElementById('links'),
       mapRoot  = document.getElementById('mindmap'),
       sidePanel= document.getElementById('sidepanel'),
@@ -655,22 +657,23 @@ function applyView(){
 
 // PAN / ZOOM / DRAG
 let pan=false, startP={}, startV={};
-viewport.addEventListener('pointerdown',e=>{
-  if(e.target!==viewport) return;
+viewportContainer.addEventListener('pointerdown',e=>{
+  if(e.target.closest('#sidepanel') || e.target.closest('.popup') || e.target.closest('#modeToggle')) return;
   closeMenus();
   pan=true;
-  viewport.setPointerCapture(e.pointerId);
+  viewportContainer.setPointerCapture(e.pointerId);
   startP={x:e.clientX,y:e.clientY};
   startV={...view};
 });
-viewport.addEventListener('pointermove',e=>{
+viewportContainer.addEventListener('pointermove',e=>{
   if(!pan) return;
   view.x = startV.x + (e.clientX - startP.x);
   view.y = startV.y + (e.clientY - startP.y);
   scheduleRender();
 });
-viewport.addEventListener('pointerup',()=>{ pan=false; });
-viewport.addEventListener('wheel',e=>{
+viewportContainer.addEventListener('pointerup',()=>{ pan=false; });
+viewportContainer.addEventListener('wheel',e=>{
+  if(e.target.closest('#sidepanel') || e.target.closest('.popup')) return;
   e.preventDefault();
   const f = e.deltaY>0 ? .97 : 1.03,
         ns = Math.min(3,Math.max(.35,view.scale*f));
@@ -803,45 +806,7 @@ const execFontSize=delta=>{
 };
 const clearHighlight=_=>{ restoreSelection(); document.execCommand && document.execCommand('removeFormat',false,null); };
 
-// ── AI VIDEO DECISION ────────────────────────────────────────────
-function decidesIfVideoNeeded(node) {
-  const label = node.label.toLowerCase();
-  const notes = (node.notes || '').toLowerCase();
-  const content = label + ' ' + notes;
-  
-  // Video-worthy content indicators
-  const videoKeywords = [
-    'algorithm', 'process', 'procedure', 'method', 'technique',
-    'implementation', 'example', 'demonstration', 'tutorial',
-    'step', 'workflow', 'calculation', 'formula', 'equation',
-    'gradient descent', 'regression', 'classification', 'neural',
-    'matrix', 'vector', 'interpolation', 'integration', 'differentiation'
-  ];
-  
-  // Content that usually doesn't need videos
-  const noVideoKeywords = [
-    'definition', 'theory', 'concept', 'overview', 'introduction',
-    'summary', 'conclusion', 'reference', 'bibliography'
-  ];
-  
-  // Check for video-worthy content
-  const hasVideoKeywords = videoKeywords.some(keyword => content.includes(keyword));
-  const hasNoVideoKeywords = noVideoKeywords.some(keyword => content.includes(keyword));
-  
-  // Additional heuristics
-  const isLeafNode = !nodes.some(n => n.parent === node.id); // No children
-  const hasDetailedNotes = notes.length > 100; // Substantial content
-  const isMathematical = /[=+\-*\/\^()∫∂∑]/.test(content); // Contains math symbols
-  const isProcessBased = content.includes('step') || content.includes('phase') || content.includes('method');
-  
-  // Decision logic
-  if (hasNoVideoKeywords && !isMathematical) return false;
-  if (hasVideoKeywords || isMathematical || isProcessBased) return true;
-  if (isLeafNode && hasDetailedNotes) return true;
-  
-  // Default: no video for simple concept nodes
-  return false;
-}
+
 
 // ── POP-UP WINDOW ────────────────────────────────────────────────
 function openPopup(n) {
@@ -905,6 +870,7 @@ function openPopup(n) {
 
   // 🡢 render stored notes through md() so the DSL markup shows up
   page.innerHTML = md(n.notes || "");
+  renderVisualisations(page);
 
   // optional per-node colours (added in earlier step)
   if (n.noteBg)    page.style.backgroundColor = n.noteBg;
@@ -1015,7 +981,9 @@ function openPopup(n) {
   const titleEl = p.querySelector("h2");
   const saveAndClose = () => {
     titleEl.innerText.trim() && (n.label = titleEl.innerText.trim());
+    removeVisualisations(page);
     n.notes = page.innerHTML;  // save WITH the generated HTML
+    renderVisualisations(page);
     build();
   };
 
@@ -1106,71 +1074,16 @@ refresh();
 </script>
 <!-- ---------- Mind‑Map Extra Features (append before </body>) ---------- -->
 <style>
-  /* Video placeholder block - horizontal layout */
-  .videoBlock{
-    width:100%;
-    max-width:500px;
-    margin:0.5rem auto;
-    border:2px solid var(--node-border);
-    border-radius:8px;
-    background:#f0f0f0;
-    overflow:hidden;
-    display:flex;
-    align-items:center;
-    gap:12px;
-    padding:8px;
-  }
-  .videoBlock .screen{
-    flex-shrink:0;
-    width:120px;
-    height:68px;
-    background:#bbb;
-    position:relative;
-    border-radius:6px;
-    overflow:hidden;
-  }
-  .videoBlock .screen::after{
-    content:'▶';
-    font-size:1.2rem;
-    color:#fff;
-    position:absolute;
-    inset:0;
-    display:flex;
-    align-items:center;
-    justify-content:center;
-  }
-  .videoBlock .content{
-    flex:1;
-    display:flex;
-    flex-direction:column;
-    gap:6px;
-    min-width:0;
-  }
-  .videoBlock .title{
-    width:100%;
-    height:0.7rem;
-    background:#ccc;
-    border-radius:3px;
-  }
-  .videoBlock .desc{
-    width:85%;
-    height:0.5rem;
-    background:#ddd;
-    border-radius:3px;
-  }
-
-  /* Visualization placeholder */
   .visBlock{
-    height:220px;
+    margin:1rem 0;
     border:3px dashed var(--node-border);
     border-radius:24px;
-    background:rgba(0,0,0,.05);
-    display:flex;
-    align-items:center;
-    justify-content:center;
-    color:#777;
-    font-style:italic;
-    margin:1rem 0;
+    overflow:hidden;
+  }
+  .visBlock iframe{
+    width:100%;
+    height:220px;
+    border:0;
   }
 
   /* Microphone button in popup header */
@@ -1233,6 +1146,25 @@ refresh();
 /* ---- Mind‑Map Extra Features ---- */
 (function(){
   /* ---------- Helpers ---------- */
+  function renderVisualisations(container){
+    container.querySelectorAll('visualisation').forEach(el=>{
+      const code=el.innerHTML;
+      const block=document.createElement('div');
+      block.className='visBlock';
+      const frame=document.createElement('iframe');
+      frame.setAttribute('sandbox','allow-scripts');
+      frame.srcdoc=code;
+      block.appendChild(frame);
+      el.style.display='none';
+      el.after(block);
+    });
+  }
+  function removeVisualisations(container){
+    container.querySelectorAll('.visBlock').forEach(b=>b.remove());
+    container.querySelectorAll('visualisation').forEach(el=>{
+      el.style.display='';
+    });
+  }
   function insertNodeAtCaret(container, node){
     const sel = window.getSelection();
     if(sel && sel.rangeCount){
@@ -1280,18 +1212,7 @@ refresh();
     const toolbar = pop.querySelector('.toolbar');
 
     if(page && toolbar){
-      /* AI-based video insertion - only for suitable content */
-      if(!page.querySelector('.videoBlock')){
-        const shouldHaveVideo = decidesIfVideoNeeded(n);
-        if(shouldHaveVideo){
-          const v = document.createElement('div');
-          v.className = 'videoBlock';
-          v.innerHTML = '<div class="screen"></div><div class="content"><div class="title"></div><div class="desc"></div></div>';
-          page.insertBefore(v, page.firstChild);
-        }
-      }
-
-      /* toolbar already has formatting buttons - no need for video/viz buttons */
+      /* toolbar already has formatting buttons */
 
       /* ---------- floating formatting toolbar on selection ---------- */
       let selToolbar = null;


### PR DESCRIPTION
## Summary
- show visualisations from `<visualisation>` blocks using sandboxed iframes
- hide visualisation source when displaying popup and restore it when saving
- added demo notes about B-splines showing highlight and graph visualisation
- allow full-screen panning by attaching handlers to `viewportContainer`
- clicking the theme toggle no longer starts panning
- fix iframe creation so embedded content appears correctly

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685d8ffd3a5883209a49a1c33df27e9d